### PR TITLE
Method to generate fake data and seed into database created 

### DIFF
--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -7,46 +7,28 @@ from dotenv import load_dotenv
 import psycopg2
 from psycopg2 import extras
 
-TOPICS = ["Immigration", "Justice system", "P Diddy",
-          "Supreme Court decisions", "Religion",
-          "Natural disasters", "Hurricane Helene", "World news",
-          "Climate change", "China", "Education", "Woke activism",
-            "Crime and law enforcement", "Guns", "Economics",
-          "Recession", "Inflation", "Cost of living", "Politics",
-          "Trump", "Kamala", "Voting", "Tim Walz", "JD Vance",
-          "War", "Israel-Gaza", "Russia-Ukraine", "Iran", "Lebanon",
-          "Social", "Race relations", "LGBTQ+ issues", "Abortion"
+TOPICS = ["Trump", 
+          "Kamala", 
+          "Israel-Gaza",
+          "Hurricanes", 
+          "Natural disasters",
+          "World news",
+          "Climate change", 
+          "Voting",
           ]
 
 
 FOX_HEADLINES = {
-    "Mexican mayor's severed head placed atop pick-up truck 6 days after taking office": 
-    ["World news", "Immigration"],
-
     "Supreme Court denies Biden administration appeal over federal emergency abortion requirement in Texas":
-
     ["Supreme Court decisions", "Justice system"],
 
-    "P Diddy sued by former employee over workplace harassment": 
-    ["P Diddy", "Justice system"],
-
     "Massive wildfires rage across California amid intense heatwave, thousands evacuated":
-
-    ["Natural disasters", "Climate change"],
+    ["Natural disasters"],
 
     "Kamala Harris faces backlash after controversial comments on immigration policies":
-
-    ["Politics", "Kamala", "Immigration"],
-
-    "China's new military drills raise tensions in the South China Sea": 
-    ["China", "World news"],
-
-    "Justice Department investigates police handling of race-related protests in Minneapolis":
-
-    ["Justice system", "Race relations", "Crime and law enforcement"],
+    ["Kamala"],
 
     "US inflation hits 40-year high, causing concerns for the economy":
-
     ["Economics", "Inflation", "Cost of living"],
 
     "Russia-Ukraine war: Latest developments and international reactions":
@@ -54,7 +36,7 @@ FOX_HEADLINES = {
     ["War", "Russia-Ukraine", "World news"],
 
     "Supreme Court takes on major gun control case with national implications":
-    
+
     ["Supreme Court decisions", "Guns", "Justice system"]
 }
 
@@ -98,20 +80,6 @@ def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
     return subscribers
 
 
-def generate_fake_assignment(table1: list[tuple], table2: list[tuple], num_assignments: int) -> list[tuple]:
-    '''Generates random assignment table rows.
-    table1 and table2 are lists of rows in the mapped tables. 
-    It's assumed that the first item in each row is the id.'''
-
-    assignments = []
-    for i in range(1, num_assignments + 1):
-        subscriber = random.choice(table1)
-        topic = random.choice(table2)
-
-        assignments.append((i, subscriber[0], topic[0]))
-    return assignments
-
-
 def generate_fake_articles(faker: Faker, num_articles: int, source_id: int, source_headlines: list) -> list[tuple]:
     '''Generates fake article table entries.
     Returns a list of tuples containing:
@@ -127,8 +95,9 @@ def generate_fake_articles(faker: Faker, num_articles: int, source_id: int, sour
 
     for i in range(1, min(len(source_headlines), num_articles) + 1):
         article_id = i
+
         article_title = source_headlines[i-1]
-        source_id = 1
+        
         polarity_score = random.triangular(-1.0, 0.0, -0.5)
         date_published = faker.date_time_between(
             start_date='-5d')

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -10,7 +10,8 @@ from psycopg2 import extras
 TOPICS = ["Immigration", "Justice system", "P Diddy",
           "Supreme Court decisions", "Religion",
           "Natural disasters", "Hurricane Helene", "World news",
-          "Climate change", "China", "Education", "Woke activism", "Crime and law enforcement", "Guns", "Economics",
+          "Climate change", "China", "Education", "Woke activism",
+            "Crime and law enforcement", "Guns", "Economics",
           "Recession", "Inflation", "Cost of living", "Politics",
           "Trump", "Kamala", "Voting", "Tim Walz", "JD Vance",
           "War", "Israel-Gaza", "Russia-Ukraine", "Iran", "Lebanon",
@@ -19,31 +20,41 @@ TOPICS = ["Immigration", "Justice system", "P Diddy",
 
 
 FOX_HEADLINES = {
-    "Mexican mayor's severed head placed atop pick-up truck 6 days after taking office": ["World news", "Immigration"],
+    "Mexican mayor's severed head placed atop pick-up truck 6 days after taking office": 
+    ["World news", "Immigration"],
 
     "Supreme Court denies Biden administration appeal over federal emergency abortion requirement in Texas":
+
     ["Supreme Court decisions", "Justice system"],
 
-    "P Diddy sued by former employee over workplace harassment": ["P Diddy", "Justice system"],
+    "P Diddy sued by former employee over workplace harassment": 
+    ["P Diddy", "Justice system"],
 
     "Massive wildfires rage across California amid intense heatwave, thousands evacuated":
+
     ["Natural disasters", "Climate change"],
 
     "Kamala Harris faces backlash after controversial comments on immigration policies":
+
     ["Politics", "Kamala", "Immigration"],
 
-    "China's new military drills raise tensions in the South China Sea": ["China", "World news"],
+    "China's new military drills raise tensions in the South China Sea": 
+    ["China", "World news"],
 
     "Justice Department investigates police handling of race-related protests in Minneapolis":
+
     ["Justice system", "Race relations", "Crime and law enforcement"],
 
     "US inflation hits 40-year high, causing concerns for the economy":
+
     ["Economics", "Inflation", "Cost of living"],
 
     "Russia-Ukraine war: Latest developments and international reactions":
+
     ["War", "Russia-Ukraine", "World news"],
 
     "Supreme Court takes on major gun control case with national implications":
+    
     ["Supreme Court decisions", "Guns", "Justice system"]
 }
 

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -144,4 +144,4 @@ if __name__ == "__main__":
     articles = generate_fake_articles(f, 12, 1, fox_headlines)
     article_assignments = generate_article_topic_assignment(fox_headlines)
     with connect() as connection:
-        insert_data_to_db(connection,topics,subs, articles, fox_headlines)
+        insert_data_to_db(connection,topics,subs, articles, article_assignments)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -1,0 +1,29 @@
+'''Generates dummy data'''
+from faker import Faker
+
+TOPICS = []
+
+
+def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
+    '''Generates fake subscribers. 
+    Returns a list of tuples containing:
+        - subscriber_id
+        - subscriber_email
+        - subscriber_first_name
+        - subscriber_surname  
+    '''
+
+    subscribers = []
+
+    for i in range(num):
+        sub_id = i
+        email = fake.unique.email()
+        first_name = fake.first_name()
+        last_name = fake.last_name()
+        subscribers.append((sub_id, email, first_name, last_name))
+    return subscribers
+
+
+if __name__ == "__main__":
+    f = Faker()
+    print(generate_fake_subscribers(f, 3))

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -71,23 +71,21 @@ def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
     return subscribers
 
 
-def generate_fake_subscriber_topic_assignments(subscribers: list[tuple], topics: list[tuple], num_assignments: int) -> list[tuple]:
-    '''Generates random subscriber to topic assignments.
-    Returns a list of tuples containing:
-        - subscriber_topic_assignment_id
-        - subscriber_id
-        - topic_id
-    '''
+def generate_fake_assignment(table1: list[tuple], table2: list[tuple], num_assignments: int) -> list[tuple]:
+    '''Generates random assignment table rows.
+    table1 and table2 are lists of rows in the mapped tables. 
+    It's assumed that the first item in each row is the id.'''
+
     assignments = []
     for i in range(1, num_assignments + 1):
-        subscriber = random.choice(subscribers)
-        topic = random.choice(topics)
+        subscriber = random.choice(table1)
+        topic = random.choice(table2)
 
         assignments.append((i, subscriber[0], topic[0]))
     return assignments
 
 
-def generate_fake_articles(faker: Faker, num_articles: int, num_sources: int) -> list[tuple]:
+def generate_fake_articles(faker: Faker, num_articles: int, source_id: int, source_headlines: list) -> list[tuple]:
     '''Generates fake article table entries.
     Returns a list of tuples containing:
         - article_id
@@ -100,9 +98,9 @@ def generate_fake_articles(faker: Faker, num_articles: int, num_sources: int) ->
 
     articles = []
 
-    for i in range(1, min(len(FOX_HEADLINES), num_articles) + 1):
+    for i in range(1, min(len(source_headlines), num_articles) + 1):
         article_id = i
-        article_title = list(FOX_HEADLINES.keys())[i-1]
+        article_title = source_headlines[i-1]
         source_id = 1
         polarity_score = random.triangular(-1.0, 0.0, -0.5)
         date_published = faker.date_time_between(
@@ -117,7 +115,10 @@ if __name__ == "__main__":
     f = Faker()
     fake_subs = generate_fake_subscribers(f, 3)
     fake_topics = generate_fake_topics()
-    fake_subs_topics = generate_fake_subscriber_topic_assignments(
+
+    fake_subs_topics = generate_fake_assignment(
         fake_subs, fake_topics, 12)
-    fake_articles = generate_fake_articles(f, 12, 2)
+
+    fox_headlines = list(FOX_HEADLINES.keys())
+    fake_articles = generate_fake_articles(f, 12, 1, fox_headlines)
     print(fake_articles)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -1,7 +1,24 @@
 '''Generates dummy data'''
 from faker import Faker
+import random
 
-TOPICS = []
+TOPICS = ["Immigration", "Justice system", "P Diddy",
+          "Supreme Court decisions", "Religion",
+          "Natural disasters", "Hurricane Helene", "World news",
+          "Climate change", "China", "Education", "Woke activism", "Crime and law enforcement", "Guns", "Economics",
+          "Recession", "Inflation", "Cost of living", "Politics",
+          "Trump", "Kamala", "Voting", "Tim Walz", "JD Vance",
+          "War", "Israel-Gaza", "Russia-Ukraine", "Iran", "Lebanon",
+          "Social", "Race relations", "LGBTQ+ issues", "Abortion"
+          ]
+
+
+def generate_fake_topics() -> list[tuple]:
+    '''Generates fake topic rows containing:
+        -topic_id
+        -topic_name
+    '''
+    return [(i+1, t) for i, t in enumerate(TOPICS)]
 
 
 def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
@@ -15,7 +32,7 @@ def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
 
     subscribers = []
 
-    for i in range(num):
+    for i in range(1, num+1):
         sub_id = i
         email = fake.unique.email()
         first_name = fake.first_name()
@@ -24,6 +41,58 @@ def generate_fake_subscribers(fake: Faker, num: int) -> list[tuple]:
     return subscribers
 
 
+def generate_fake_subscriber_topic_assignments(subscribers: list[tuple], topics: list[tuple], num_assignments: int) -> list[tuple]:
+    '''Generates random subscriber to topic assignments.
+    Returns a list of tuples containing:
+        - subscriber_topic_assignment_id
+        - subscriber_id
+        - topic_id
+    '''
+    assignments = []
+    for i in range(1, num_assignments + 1):
+        subscriber = random.choice(subscribers)
+        topic = random.choice(topics)
+
+        assignments.append((i, subscriber[0], topic[0]))
+    return assignments
+
+
+def generate_fake_articles(faker: Faker, num_articles: int, num_sources: int) -> list[tuple]:
+    '''Generates fake article table entries.
+    Returns a list of tuples containing:
+        - article_id
+        - article_title
+        - polarity_score
+        - source_id
+        - date_published
+        - article_url
+    '''
+    fake = Faker()
+    articles = []
+    source_polarity = [round(random.uniform(-1.0, 1.0), 2)
+                       for _ in range(num_sources)]
+
+    for i in range(1, num_articles + 1):
+        article_id = i
+        article_title = fake.sentence()
+        source_id = random.randint(1, num_sources)
+
+        polarity_score = random.triangular(source_polarity[source_id-1])
+
+        date_published = fake.date_time_between(
+            start_date='-5d', end_date='today')
+
+        article_url = fake.url()
+
+        articles.append((article_id, article_title, polarity_score,
+                        source_id, date_published, article_url))
+
+    return articles
+
+
 if __name__ == "__main__":
     f = Faker()
-    print(generate_fake_subscribers(f, 3))
+    fake_subs = generate_fake_subscribers(f, 3)
+    fake_topics = generate_fake_topics()
+    fake_subs_topics = generate_fake_subscriber_topic_assignments(
+        fake_subs, fake_topics, 12)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -13,6 +13,36 @@ TOPICS = ["Immigration", "Justice system", "P Diddy",
           ]
 
 
+FOX_HEADLINES = {
+    "Mexican mayor's severed head placed atop pick-up truck 6 days after taking office": ["World news", "Immigration"],
+
+    "Supreme Court denies Biden administration appeal over federal emergency abortion requirement in Texas":
+    ["Supreme Court decisions", "Justice system"],
+
+    "P Diddy sued by former employee over workplace harassment": ["P Diddy", "Justice system"],
+
+    "Massive wildfires rage across California amid intense heatwave, thousands evacuated":
+    ["Natural disasters", "Climate change"],
+
+    "Kamala Harris faces backlash after controversial comments on immigration policies":
+    ["Politics", "Kamala", "Immigration"],
+
+    "China's new military drills raise tensions in the South China Sea": ["China", "World news"],
+
+    "Justice Department investigates police handling of race-related protests in Minneapolis":
+    ["Justice system", "Race relations", "Crime and law enforcement"],
+
+    "US inflation hits 40-year high, causing concerns for the economy":
+    ["Economics", "Inflation", "Cost of living"],
+
+    "Russia-Ukraine war: Latest developments and international reactions":
+    ["War", "Russia-Ukraine", "World news"],
+
+    "Supreme Court takes on major gun control case with national implications":
+    ["Supreme Court decisions", "Guns", "Justice system"]
+}
+
+
 def generate_fake_topics() -> list[tuple]:
     '''Generates fake topic rows containing:
         -topic_id
@@ -67,26 +97,19 @@ def generate_fake_articles(faker: Faker, num_articles: int, num_sources: int) ->
         - date_published
         - article_url
     '''
-    fake = Faker()
+
     articles = []
-    source_polarity = [round(random.uniform(-1.0, 1.0), 2)
-                       for _ in range(num_sources)]
 
-    for i in range(1, num_articles + 1):
+    for i in range(1, min(len(FOX_HEADLINES), num_articles) + 1):
         article_id = i
-        article_title = fake.sentence()
-        source_id = random.randint(1, num_sources)
-
-        polarity_score = random.triangular(source_polarity[source_id-1])
-
-        date_published = fake.date_time_between(
-            start_date='-5d', end_date='today')
-
-        article_url = fake.url()
-
+        article_title = list(FOX_HEADLINES.keys())[i-1]
+        source_id = 1
+        polarity_score = random.triangular(-1.0, 0.0, -0.5)
+        date_published = faker.date_time_between(
+            start_date='-5d')
+        article_url = faker.url()
         articles.append((article_id, article_title, polarity_score,
                         source_id, date_published, article_url))
-
     return articles
 
 
@@ -96,3 +119,5 @@ if __name__ == "__main__":
     fake_topics = generate_fake_topics()
     fake_subs_topics = generate_fake_subscriber_topic_assignments(
         fake_subs, fake_topics, 12)
+    fake_articles = generate_fake_articles(f, 12, 2)
+    print(fake_articles)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -1,7 +1,8 @@
 '''Generates dummy data'''
-from faker import Faker
-import random
 from os import environ as ENV
+import random
+from faker import Faker
+
 from dotenv import load_dotenv
 import psycopg2
 from psycopg2 import extras
@@ -144,23 +145,22 @@ def insert_data_to_db(conn, fake_topics: list[tuple], fake_subs: list[tuple], fa
 
         extras.execute_values(cursor, 
             "INSERT INTO subscriber_topic_assignments (subscriber_topic_assignment_id, subscriber_id, topic_id) VALUES %s", 
-            generate_fake_assignment(fake_subs, fake_topics))
+            generate_fake_assignment(fake_subs, fake_topics, 15))
         
 
         extras.execute_values(cursor, 
             "INSERT INTO article_topic_assignment (subscriber_topic_assignment_id, topic_id, article_id) VALUES %s", 
-            generate_fake_assignment(fake_topics, fake_articles))
+            generate_fake_assignment(fake_topics, fake_articles, 18))
         
         conn.commit()
 
 if __name__ == "__main__":
     f = Faker()
-    fake_subs = generate_fake_subscribers(f, 3)
-    fake_topics = generate_fake_topics()
-
-    fake_subs_topics = generate_fake_assignment(
-        fake_subs, fake_topics, 12)
+    subs = generate_fake_subscribers(f, 3)
+    topics = generate_fake_topics()
 
     fox_headlines = list(FOX_HEADLINES.keys())
-    fake_articles = generate_fake_articles(f, 12, 1, fox_headlines)
-    print(fake_articles)
+    articles = generate_fake_articles(f, 12, 1, fox_headlines)
+
+    with connect() as connection:
+        insert_data_to_db(connection,topics,subs, articles)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -60,7 +60,7 @@ def connect():
 
 def generate_fake_topics() -> list[tuple]:
     '''Generates fake topic rows.'''
-    
+
     return [(i+1, t) for i, t in enumerate(TOPICS)]
 
 
@@ -124,7 +124,7 @@ def insert_data_to_db(conn, fake_topics: list[tuple], fake_subs: list[tuple], fa
             fake_topics)
 
         extras.execute_values(cursor, """
-            INSERT INTO subscribers 
+            INSERT INTO subscriber
             (subscriber_id, subscriber_email, subscriber_first_name, 
             subscriber_surname) 
             VALUES %s""", fake_subs)

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -1,4 +1,5 @@
 '''Generates dummy data'''
+
 from os import environ as ENV
 import random
 from faker import Faker
@@ -47,6 +48,7 @@ FOX_HEADLINES = {
 
 def connect():
     '''Return a connection to the RDS database.'''
+
     load_dotenv()
     return psycopg2.connect(dbname=ENV["DB_NAME"],
                             host=ENV["DB_HOST"],
@@ -80,6 +82,7 @@ def generate_fake_articles(
         source_headlines: list
         ) -> list[tuple]:
     '''Generates fake article table entries.'''
+
     rows = []
 
     for i in range(1, min(len(source_headlines), num_articles) + 1):
@@ -113,6 +116,7 @@ def generate_article_topic_assignment(headlines: dict) -> list[tuple]:
 def insert_data_to_db(conn, fake_topics: list[tuple], fake_subs: list[tuple], fake_articles: list[tuple], assignments:list[tuple]
         ):
     '''Inserts fake data into the database'''
+
     with conn.cursor() as cursor:
 
         extras.execute_values(cursor, """INSERT INTO topic (topic_id, topic_name) VALUES %s""", 

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -60,6 +60,7 @@ def connect():
 
 def generate_fake_topics() -> list[tuple]:
     '''Generates fake topic rows.'''
+    
     return [(i+1, t) for i, t in enumerate(TOPICS)]
 
 

--- a/database/generate_dummy_data.py
+++ b/database/generate_dummy_data.py
@@ -1,6 +1,9 @@
 '''Generates dummy data'''
 from faker import Faker
 import random
+from os import environ as ENV
+from dotenv import load_dotenv
+import psycopg2
 
 TOPICS = ["Immigration", "Justice system", "P Diddy",
           "Supreme Court decisions", "Religion",
@@ -41,6 +44,17 @@ FOX_HEADLINES = {
     "Supreme Court takes on major gun control case with national implications":
     ["Supreme Court decisions", "Guns", "Justice system"]
 }
+
+
+def connect() -> Connection:
+    '''Return a connection to redshift.'''
+
+    return psycopg2.connect(dbname=db_name,
+                            host=ENV["DATABASE_HOST"],
+                            user=ENV["DATABASE_USERNAME"],
+                            port=ENV["DATABASE_PORT"],
+                            password=ENV["DATABASE_PASSWORD"],
+                            cursor_factory=psycopg2.extras.RealDictCursor)
 
 
 def generate_fake_topics() -> list[tuple]:

--- a/database/requirements.txt
+++ b/database/requirements.txt
@@ -1,0 +1,4 @@
+python-dotenv
+pylint
+pytest
+psycopg2

--- a/database/requirements.txt
+++ b/database/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 pylint
 pytest
 psycopg2
+faker


### PR DESCRIPTION
Script functionality:
- Connects to the database 
- generates fake subscribers, topics, mappings, to real headlines
- fake polarity score, sampled randomly but biased towards the negative (for fox news)

possible future improvements:
- functions have parameters specifying number of fake data rows to generate already, so could include this as a CLI parameter. 
- Need to double check queries against the creating tables schema
- Assumes sources have already been seeded. Need to check this.