### PR TITLE
Created methods to convert HTML formatting tags out of article content

### DIFF
--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -1,6 +1,6 @@
 '''Cleaning HTML content'''
-from bs4 import BeautifulSoup
 import re
+from bs4 import BeautifulSoup
 
 
 def clean_html_tags(html_text: str) -> str:

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -20,8 +20,10 @@ def clean_multiple_spaces(text: str) -> str:
     return re.sub(r'\s+', ' ', text)
 
 
-def clean_ads(article_content: str) -> str:
-    '''Returns article content with HTML Hyperlink text removed.'''
+def clean_content(content: str, is_html: bool):
+    if is_html:
+        content = clean_html_tags(content)
+    return clean_multiple_spaces(content)
 
 
 if __name__ == "__main__":

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 
 
 def clean_html_tags(html_text: str) -> str:
-    '''Returns text with HTML tags removed'''
+    """Returns text with HTML tags removed"""
     soup = BeautifulSoup(html_text, "html.parser")
 
     for a_tag in soup.find_all('a'):
@@ -16,11 +16,13 @@ def clean_html_tags(html_text: str) -> str:
 
 
 def clean_multiple_spaces(text: str) -> str:
-    '''Returns text multiple spaces removed'''
+    """Returns text multiple spaces removed"""
     return re.sub(r'\s+', ' ', text)
 
 
 def clean_content(content: str, is_html: bool):
+    """Cleans HTML content including removal of ads and handling the extra
+    whitespace."""
     if is_html:
         content = clean_html_tags(content)
     return clean_multiple_spaces(content)

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -1,10 +1,11 @@
 '''Cleaning HTML content'''
-
+from bs4 import BeautifulSoup
 import re
 
 
 def clean_html_tags(html_text: str) -> str:
     '''Returns text with HTML tags removed'''
+    return BeautifulSoup(html_text, "html.parser").get_text()
 
 
 def clean_multiple_spaces(text: str) -> str:

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -1,0 +1,19 @@
+'''Cleaning HTML content'''
+
+import re
+
+
+def clean_html_tags(html_text: str) -> str:
+    '''Returns text with HTML tags removed'''
+
+
+def clean_multiple_spaces(text: str) -> str:
+    '''Returns text multiple spaces removed'''
+
+
+def clean_ads(article_content: str) -> str:
+    '''Returns article content with HTML Hyperlink text removed.'''
+
+
+if __name__ == "__main__":
+    ...

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -5,7 +5,14 @@ import re
 
 def clean_html_tags(html_text: str) -> str:
     '''Returns text with HTML tags removed'''
-    return BeautifulSoup(html_text, "html.parser").get_text()
+    soup = BeautifulSoup(html_text, "html.parser")
+
+    for a_tag in soup.find_all('a'):
+        strong_tag = a_tag.find('strong')
+        if strong_tag:
+            a_tag.decompose()
+
+    return soup.get_text()
 
 
 def clean_multiple_spaces(text: str) -> str:

--- a/news_sentiment_analyser/clean_content.py
+++ b/news_sentiment_analyser/clean_content.py
@@ -10,6 +10,7 @@ def clean_html_tags(html_text: str) -> str:
 
 def clean_multiple_spaces(text: str) -> str:
     '''Returns text multiple spaces removed'''
+    return re.sub(r'\s+', ' ', text)
 
 
 def clean_ads(article_content: str) -> str:

--- a/news_sentiment_analyser/requirements.txt
+++ b/news_sentiment_analyser/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 pandas
 psycopg2
 boto3
+bs4

--- a/news_sentiment_analyser/test_clean_content.py
+++ b/news_sentiment_analyser/test_clean_content.py
@@ -14,7 +14,12 @@ def test_clean_html_tags(html, expected):
     assert clean_html_tags(html) == expected
 
 
-def test_clean_multiple_spaces():
-    '''Tests that multiple spaces are replaced by a single space'''
-
-    assert True
+@pytest.mark.parametrize("html, expected", [
+    ("""We’ve seen over the  past century that, in      general, natural disasters are killing fewer      people.""",
+     """We’ve seen over the past century that, in general, natural disasters are killing fewer people."""),
+    ("   ", " "),
+    (" ", " ")
+])
+def test_clean_multiple_spaces(html, expected):
+    '''Tests that html tags are cleaned as expected'''
+    assert clean_multiple_spaces(html) == expected

--- a/news_sentiment_analyser/test_clean_content.py
+++ b/news_sentiment_analyser/test_clean_content.py
@@ -7,7 +7,9 @@ from clean_content import clean_ads, clean_html_tags, clean_multiple_spaces
     ("""We’ve seen over the past century that, in general, <a href="https: // www.vox.com/23150467/natural-disaster-climate-change-early-warning-hurricane-wildfire">natural disasters are killing fewer people</a>.""",
      """We’ve seen over the past century that, in general, natural disasters are killing fewer people."""),
     ("", ""),
-    (" ", " ")
+    (" ", " "),
+    ("""During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations, the study noted, driven by advancements in <a href="https: // www.foxnews.com/health" target="_blank" rel="noopener">public health</a>.</p><p><a href="https: // www.foxnews.com/health/ultra-processed-foods-repercussions-childrens-health-nutritionist-warns" target="_blank" rel="noopener"><strong>ULTRA-PROCESSED FOODS MAKE UP 60% OF AMERICA'S DIET, WHO'S AT BIGGEST RISK</strong></a></p><p>""",
+     "During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations, the study noted, driven by advancements in public health.")
 ])
 def test_clean_html_tags(html, expected):
     '''Tests that html tags are cleaned as expected'''

--- a/news_sentiment_analyser/test_clean_content.py
+++ b/news_sentiment_analyser/test_clean_content.py
@@ -1,4 +1,6 @@
+# pylint: skip-file
 """Tests the content cleaning methods"""
+
 import pytest
 from clean_content import clean_html_tags, clean_multiple_spaces, clean_content
 

--- a/news_sentiment_analyser/test_clean_content.py
+++ b/news_sentiment_analyser/test_clean_content.py
@@ -1,15 +1,19 @@
 """Tests the content cleaning methods"""
 import pytest
-from clean_content import clean_ads, clean_html_tags, clean_multiple_spaces
+from clean_content import clean_html_tags, clean_multiple_spaces, clean_content
+
+
+def test_clean_content():
+    test_content = """During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations,the study noted, driven by advancements in <a href="https: // www.foxnews.com/health" target="_blank" rel="noopener">public health</a>.</p><p><a href="https: // www.foxnews.com/health/ultra-processed-foods-repercussions-childrens-health-nutritionist-warns" target="_blank" rel="noopener"><strong>ULTRA-PROCESSED FOODS MAKE UP 60% OF AMERICA'S DIET, WHO'S AT BIGGEST RISK</strong></a></p><p>"""
+    assert clean_content(
+        test_content, True) == "During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations,the study noted, driven by advancements in public health."
 
 
 @pytest.mark.parametrize("html, expected", [
-    ("""We’ve seen over the past century that, in general, <a href="https: // www.vox.com/23150467/natural-disaster-climate-change-early-warning-hurricane-wildfire">natural disasters are killing fewer people</a>.""",
+    ("""We’ve seen over the past century that, in general,<a href="https: // www.vox.com/23150467/natural-disaster-climate-change-early-warning-hurricane-wildfire"> natural disasters are killing fewer people</a>.""",
      """We’ve seen over the past century that, in general, natural disasters are killing fewer people."""),
     ("", ""),
     (" ", " "),
-    ("""During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations, the study noted, driven by advancements in <a href="https: // www.foxnews.com/health" target="_blank" rel="noopener">public health</a>.</p><p><a href="https: // www.foxnews.com/health/ultra-processed-foods-repercussions-childrens-health-nutritionist-warns" target="_blank" rel="noopener"><strong>ULTRA-PROCESSED FOODS MAKE UP 60% OF AMERICA'S DIET, WHO'S AT BIGGEST RISK</strong></a></p><p>""",
-     "During the 20th century, human life expectancy at birth rose by about 30 years in high-income nations, the study noted, driven by advancements in public health.")
 ])
 def test_clean_html_tags(html, expected):
     '''Tests that html tags are cleaned as expected'''

--- a/news_sentiment_analyser/test_clean_content.py
+++ b/news_sentiment_analyser/test_clean_content.py
@@ -1,0 +1,20 @@
+"""Tests the content cleaning methods"""
+import pytest
+from clean_content import clean_ads, clean_html_tags, clean_multiple_spaces
+
+
+@pytest.mark.parametrize("html, expected", [
+    ("""We’ve seen over the past century that, in general, <a href="https: // www.vox.com/23150467/natural-disaster-climate-change-early-warning-hurricane-wildfire">natural disasters are killing fewer people</a>.""",
+     """We’ve seen over the past century that, in general, natural disasters are killing fewer people."""),
+    ("", ""),
+    (" ", " ")
+])
+def test_clean_html_tags(html, expected):
+    '''Tests that html tags are cleaned as expected'''
+    assert clean_html_tags(html) == expected
+
+
+def test_clean_multiple_spaces():
+    '''Tests that multiple spaces are replaced by a single space'''
+
+    assert True


### PR DESCRIPTION
- Removed some ads that appear in the content between `<a><strong>` tags (e.g. see fox news). We will need to note down how different sources format their ads within content when adding new sources/ think about adding new methods to handle the different cases if needed later on.
- Removed HTML formatting from content 
- Script will be used for preprocessing before sentiment extraction. 
- Added test file.

@indiah444, I'm currently using these methods to clean data for the test sample I'm working with for sentiment analysis, but it seems like for the whole pipeline we have two options:

- clean the HTML tags/formatting/ads once during extraction (possibly in the same script that stopwords and whitespace are being cleaned)
- clean the HTML tags/formatting/ads only before pre-processing 

(First option can be handled by just copying over the HTML cleaning methods into your cleaning script, should be quick)

Advantage of the second method is that we won't have to reformat database "article content" entries into HTML again if we want to display content in emails/on the dashboard. Advantage of the first is that we only have to clean these tags away once.  Either way it's a relatively inconsequential decision (I think).
